### PR TITLE
Add typedefs to core/Breadcrumb

### DIFF
--- a/packages/core/types/breadcrumb.d.ts
+++ b/packages/core/types/breadcrumb.d.ts
@@ -5,6 +5,14 @@ declare class Breadcrumb {
   public metadata: { [key: string]: any };
   public type: BreadcrumbType;
   public timestamp: Date;
+
+  constructor (message: string, metadata: Breadcrumb["metadata"], type: Breadcrumb['type'], timestamp?: Date)
+  toJSON(): {
+    type: Breadcrumb['type']
+    name: Breadcrumb['message']
+    timestamp: Breadcrumb['timestamp']
+    metaData: Breadcrumb['metadata']
+  }
 }
 
 export default Breadcrumb


### PR DESCRIPTION
## Goal

We use `@bugsnag/core` in our project, and use the `onBreadcrumb` option as per [the docs](https://docs.bugsnag.com/platforms/javascript/customizing-breadcrumbs/) to filter and modify breadcrumb metadata. In order to test this behaviour, we need to create `Breadcrumb` instances with specific metadata, however the type definitions in the repo don't include the constructor.

This PR adds the appropriate type definitions to `Breadcrumb`.